### PR TITLE
Fix PHP notice: Undefined index: samples

### DIFF
--- a/src/Prometheus/MetricFamilySamples.php
+++ b/src/Prometheus/MetricFamilySamples.php
@@ -40,8 +40,10 @@ class MetricFamilySamples
         $this->type = $data['type'];
         $this->help = $data['help'];
         $this->labelNames = $data['labelNames'];
-        foreach ($data['samples'] as $sampleData) {
-            $this->samples[] = new Sample($sampleData);
+        if(isset($data['samples'])) {
+            foreach ($data['samples'] as $sampleData) {
+                $this->samples[] = new Sample($sampleData);
+            }
         }
     }
 


### PR DESCRIPTION
collectHistograms() in the storage adapters does not define ['samples'] as the default array keys and as such a notice is thrown when the MetricFamilySamples::__construct($data) is called when no samples are available.